### PR TITLE
Quit worker thread if engine.connection() fail

### DIFF
--- a/sqlalchemy_aio/asyncio.py
+++ b/sqlalchemy_aio/asyncio.py
@@ -19,8 +19,8 @@ class AsyncioThreadWorker(ThreadWorker):
         self._loop = loop
 
         if branch_from is None:
-            self._request_queue = asyncio.Queue(1)
-            self._response_queue = asyncio.Queue(1)
+            self._request_queue = asyncio.Queue(1, loop=loop)
+            self._response_queue = asyncio.Queue(1, loop=loop)
             self._thread = threading.Thread(target=self.thread_fn, daemon=True)
             self._thread.start()
         else:

--- a/sqlalchemy_aio/base.py
+++ b/sqlalchemy_aio/base.py
@@ -104,7 +104,7 @@ class AsyncEngine(Identified, ABC):
         worker = self._make_worker()
         try:
             connection = await worker.run(self._engine.connect)
-        except Exception as e:
+        except Exception:
             await worker.quit()
             raise
         return AsyncConnection(connection, worker, self)

--- a/sqlalchemy_aio/base.py
+++ b/sqlalchemy_aio/base.py
@@ -102,7 +102,11 @@ class AsyncEngine(Identified, ABC):
 
     async def _make_async_connection(self):
         worker = self._make_worker()
-        connection = await worker.run(self._engine.connect)
+        try:
+            connection = await worker.run(self._engine.connect)
+        except Exception as e:
+            await worker.quit()
+            raise
         return AsyncConnection(connection, worker, self)
 
     def begin(self, close_with_result=False):


### PR DESCRIPTION
This fixes #18, by waiting for the worker thread to quit if the engine connecion fails